### PR TITLE
Support partitioning configuration for tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 * Add cross-database utils macros
+* Support partitioning configuration for tables
 * Fix and extend seed types
 * Tidy generated SQL formatting
 

--- a/README.md
+++ b/README.md
@@ -77,8 +77,15 @@ profile_name:
 | ------ | ----------- | -------- | ------- |
 | `primary_key` | Primary key expression to use during table creation | `yes` | |
 | `store_type` | Type of table. Available options are `row` and `column` | `no` | `row` |
+| `partition_by` | Columns for the `PARTITION BY <method> (...)` clause. Column-oriented tables only (`store_type='column'`) | `no` | |
+| `partition_method` | Partitioning method for `partition_by`. Currently YDB supports only `hash` | `no` | `hash` |
 | `auto_partitioning_by_size` | Enable automatic partitioning by size. Available options are `ENABLED` and `DISABLED` | `no` | |
+| `auto_partitioning_by_load` | Enable automatic partitioning by load. Available options are `ENABLED` and `DISABLED` | `no` | |
 | `auto_partitioning_partition_size_mb` | Partition size in megabytes for automatic partitioning | `no` | |
+| `auto_partitioning_min_partitions_count` | Minimum number of partitions | `no` | |
+| `auto_partitioning_max_partitions_count` | Maximum number of partitions | `no` | |
+| `uniform_partitions` | Number of pre-created uniform partitions (`Uint32`/`Uint64` keys) | `no` | |
+| `partition_at_keys` | Explicit partition boundary keys, e.g. `(100, 200, 300)` | `no` | |
 | `ttl` | Time-to-live (TTL) expression for automatic data expiration | `no` | |
 
 #### Incremental
@@ -88,8 +95,15 @@ profile_name:
 | `incremental_strategy` | Strategy of incremental materialization. Current adapter supports only `merge` strategy, which will use `YDB`'s `UPSERT` operation. | `no` | `default` |
 | `primary_key` | Primary key expression to use during table creation | `yes` | |
 | `store_type` | Type of table. Available options are `row` and `column` | `no` | `row` |
+| `partition_by` | Columns for the `PARTITION BY <method> (...)` clause. Column-oriented tables only (`store_type='column'`) | `no` | |
+| `partition_method` | Partitioning method for `partition_by`. Currently YDB supports only `hash` | `no` | `hash` |
 | `auto_partitioning_by_size` | Enable automatic partitioning by size. Available options are `ENABLED` and `DISABLED` | `no` | |
+| `auto_partitioning_by_load` | Enable automatic partitioning by load. Available options are `ENABLED` and `DISABLED` | `no` | |
 | `auto_partitioning_partition_size_mb` | Partition size in megabytes for automatic partitioning | `no` | |
+| `auto_partitioning_min_partitions_count` | Minimum number of partitions | `no` | |
+| `auto_partitioning_max_partitions_count` | Maximum number of partitions | `no` | |
+| `uniform_partitions` | Number of pre-created uniform partitions (`Uint32`/`Uint64` keys) | `no` | |
+| `partition_at_keys` | Explicit partition boundary keys, e.g. `(100, 200, 300)` | `no` | |
 | `ttl` | Time-to-live (TTL) expression for automatic data expiration | `no` | |
 
 ##### Example table configuration
@@ -108,6 +122,19 @@ select
     name,
     created_at
 from {{ ref('source_table') }}
+```
+
+##### Example column-oriented table with partitioning
+
+```sql
+{{ config(
+    primary_key='id',
+    store_type='column',
+    partition_by='id',
+    auto_partitioning_min_partitions_count=4
+) }}
+
+select id, name, created_at from {{ ref('source_table') }}
 ```
 
 #### Seed

--- a/dbt/include/ydb/macros/materializations/models/table.sql
+++ b/dbt/include/ydb/macros/materializations/models/table.sql
@@ -10,19 +10,30 @@
 
   {%- set table_options = ['STORE = ' ~ store_type] -%}
 
-  {%- set auto_partitioning_by_size = model['config'].get('auto_partitioning_by_size') -%}
-  {%- if auto_partitioning_by_size is not none -%}
-    {%- do table_options.append('AUTO_PARTITIONING_BY_SIZE = ' ~ auto_partitioning_by_size) -%}
-  {%- endif -%}
+  {%- set with_settings = [
+      ('auto_partitioning_by_size', 'AUTO_PARTITIONING_BY_SIZE'),
+      ('auto_partitioning_by_load', 'AUTO_PARTITIONING_BY_LOAD'),
+      ('auto_partitioning_partition_size_mb', 'AUTO_PARTITIONING_PARTITION_SIZE_MB'),
+      ('auto_partitioning_min_partitions_count', 'AUTO_PARTITIONING_MIN_PARTITIONS_COUNT'),
+      ('auto_partitioning_max_partitions_count', 'AUTO_PARTITIONING_MAX_PARTITIONS_COUNT'),
+      ('uniform_partitions', 'UNIFORM_PARTITIONS'),
+      ('partition_at_keys', 'PARTITION_AT_KEYS'),
+      ('ttl', 'TTL'),
+  ] -%}
+  {%- for cfg_key, sql_key in with_settings -%}
+    {%- set value = model['config'].get(cfg_key) -%}
+    {%- if value is not none -%}
+      {%- do table_options.append(sql_key ~ ' = ' ~ value) -%}
+    {%- endif -%}
+  {%- endfor -%}
 
-  {%- set auto_partitioning_partition_size_mb = model['config'].get('auto_partitioning_partition_size_mb') -%}
-  {%- if auto_partitioning_partition_size_mb is not none -%}
-    {%- do table_options.append('AUTO_PARTITIONING_PARTITION_SIZE_MB = ' ~ auto_partitioning_partition_size_mb) -%}
+  {%- set partition_by = model['config'].get('partition_by') -%}
+  {%- if partition_by is not none and partition_by is not string and partition_by is sequence -%}
+    {%- set partition_by = partition_by | join(', ') -%}
   {%- endif -%}
-
-  {%- set ttl_expr = model['config'].get('ttl') -%}
-  {%- if ttl_expr is not none -%}
-    {%- do table_options.append('TTL = ' ~ ttl_expr) -%}
+  {%- set partition_method = model['config'].get('partition_method', 'hash') -%}
+  {%- if partition_by is not none and store_type != 'column' -%}
+    {{ exceptions.raise_compiler_error("Configuration parameter `partition_by` requires `store_type='column'` for model '" + model.name + "'") }}
   {%- endif -%}
 
   {{ sql_header if sql_header is not none }}
@@ -38,7 +49,8 @@ create {% if temporary %}temporary {% endif %}table
 {{ get_table_columns_and_constraints() }}
   {%- set sql = get_select_subquery(sql) %}
 {% endif %}
-WITH (
+{% if partition_by is not none %}PARTITION BY {{ partition_method | upper }} ({{ partition_by }})
+{% endif %}WITH (
   {{ table_options | join(',\n  ') }}
 )
 as

--- a/tests/functional/adapter/basic/test_partition.py
+++ b/tests/functional/adapter/basic/test_partition.py
@@ -1,0 +1,87 @@
+import pytest
+
+from dbt.tests.util import relation_from_name, run_dbt
+
+seeds__data_csv = """id,name
+1,alice
+2,bob
+3,carol
+"""
+
+# Column-oriented table with an explicit PARTITION BY HASH clause.
+column_partition_sql = """
+{{ config(
+    materialized='table',
+    store_type='column',
+    primary_key='id',
+    partition_by='id',
+    partition_method='hash',
+    auto_partitioning_min_partitions_count=4
+) }}
+select * from {{ ref('data') }}
+"""
+
+# Row-oriented table with WITH(...) partitioning settings.
+row_partition_sql = """
+{{ config(
+    materialized='table',
+    store_type='row',
+    primary_key='id',
+    auto_partitioning_by_load='ENABLED',
+    auto_partitioning_min_partitions_count=2,
+    auto_partitioning_max_partitions_count=8
+) }}
+select * from {{ ref('data') }}
+"""
+
+# PARTITION BY HASH is column-only -> should raise at compile time on a row table.
+bad_partition_sql = """
+{{ config(
+    materialized='table',
+    store_type='row',
+    primary_key='id',
+    partition_by='id'
+) }}
+select * from {{ ref('data') }}
+"""
+
+
+class BasePartition:
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"data.csv": seeds__data_csv}
+
+    def _assert_rows(self, project, name, expected=3):
+        relation = relation_from_name(project.adapter, name)
+        result = project.run_sql(f"select count(*) as n from {relation}", fetch="one")
+        assert result[0] == expected
+
+
+class TestColumnPartitionBy(BasePartition):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"col_partitioned.sql": column_partition_sql}
+
+    def test_partition_by(self, project):
+        run_dbt(["build"])
+        self._assert_rows(project, "col_partitioned")
+
+
+class TestRowPartitionSettings(BasePartition):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"row_partitioned.sql": row_partition_sql}
+
+    def test_partition_settings(self, project):
+        run_dbt(["build"])
+        self._assert_rows(project, "row_partitioned")
+
+
+class TestPartitionByRequiresColumnStore(BasePartition):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"bad_partitioned.sql": bad_partition_sql}
+
+    def test_compile_error(self, project):
+        run_dbt(["seed"])
+        run_dbt(["run"], expect_pass=False)


### PR DESCRIPTION
Closes #34.

Adds partitioning configuration to the `table` (and `incremental`) materialization.

**Column-oriented tables** — new `partition_by` config renders the `PARTITION BY <method> (...)` clause. The method comes from `partition_method` (default `hash`, currently the only method YDB supports) so it isn't hardcoded — future methods just pass through the config:

```sql
{{ config(materialized='table', store_type='column',
          primary_key='id', partition_by='id',
          auto_partitioning_min_partitions_count=4) }}
select id, name from {{ ref('src') }}
```

`partition_by` is guarded to column stores (compile error otherwise, since YQL only allows the clause on column-oriented tables).

**New `WITH(...)` settings** (row and column, as applicable): `auto_partitioning_by_load`, `auto_partitioning_min_partitions_count`, `auto_partitioning_max_partitions_count`, `uniform_partitions`, `partition_at_keys` (existing `auto_partitioning_by_size` / `auto_partitioning_partition_size_mb` / `ttl` unchanged).

Verified that `PARTITION BY HASH` works with `CREATE TABLE ... AS SELECT`. Tests in `tests/functional/adapter/basic/test_partition.py`; README/CHANGELOG updated.
