### PR TITLE
Stage incremental rows in a view and split SQL headers per statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* Incremental models stage rows in a view instead of a temp table, so the dataset is written once
+* Add `tmp_relation_type` to opt back into staging via a temp table
+* Add per-statement SQL headers: `merge_sql_header` and `tmp_sql_header`
+
 ## 0.0.15 ##
 * Add cross-database utils macros
 * Support partitioning configuration for tables

--- a/README.md
+++ b/README.md
@@ -105,6 +105,57 @@ profile_name:
 | `uniform_partitions` | Number of pre-created uniform partitions (`Uint32`/`Uint64` keys) | `no` | |
 | `partition_at_keys` | Explicit partition boundary keys, e.g. `(100, 200, 300)` | `no` | |
 | `ttl` | Time-to-live (TTL) expression for automatic data expiration | `no` | |
+| `tmp_relation_type` | How the rows are staged for the `UPSERT`: as a `view` (the model query is read once, straight into the target) or as a `table` (the result set is materialized first, then copied) | `no` | `view` |
+| `merge_sql_header` | SQL header for the `UPSERT` statement. Replaces `sql_header` for that statement only | `no` | value of `sql_header` |
+| `tmp_sql_header` | SQL header for the statement that creates the temp relation. Replaces `sql_header` for that statement only | `no` | value of `sql_header` |
+
+##### Staging: view or table
+
+On an incremental run the adapter first stages the model's result set and then
+`UPSERT`s it into the target. By default the staging relation is a **view**, so the
+model query is planned into the `UPSERT` itself and the data is written exactly once:
+
+```sql
+create view `schema/model__dbt_tmp` with (security_invoker = TRUE) as select ... ;
+upsert into `schema/model` select `a`, `b` from `schema/model__dbt_tmp`;
+```
+
+Set `tmp_relation_type='table'` to go back to staging into a real table
+(`create table ... as select`, then `upsert ... from` it). That costs one extra full
+write plus a read of the same volume, but it reads the sources before the target is
+touched, which is what you want if:
+
+* the model query is non-deterministic or reads a source that keeps changing, and you
+  would rather it be snapshotted before the write starts;
+* the model reads `{{ this }}` and you do not want the read and the write of the target
+  to happen inside one query;
+* the single query that reads the sources and writes the target runs into transaction
+  limits.
+
+Model contracts always stage into a table -- a view carries no column definitions to
+assert the contract against.
+
+View staging needs a cluster with `CREATE VIEW` support; where views are not enabled,
+incremental models need `tmp_relation_type='table'`.
+
+##### Per-statement SQL headers
+
+Building a model takes more than one statement, and `sql_header` goes in front of every
+one of them. Statements differ in what they do and how they are planned, so a header
+that fits one of them is not necessarily valid for the next. `merge_sql_header` and
+`tmp_sql_header` replace `sql_header` for their own statement; an empty string means
+"no header here":
+
+```sql
+{{ config(
+    materialized='incremental',
+    unique_key='id',
+    primary_key='id',
+    sql_header='PRAGMA ydb.DisableBlockExecution = "true";',
+    merge_sql_header='',
+    tmp_sql_header=''
+) }}
+```
 
 ##### Example table configuration
 

--- a/dbt/include/ydb/macros/materializations/models/incremental/incremental.sql
+++ b/dbt/include/ydb/macros/materializations/models/incremental/incremental.sql
@@ -5,7 +5,6 @@
   {%- set existing_relation = load_cached_relation(this) -%}
 
   {%- set target_relation = this.incorporate(type='table') -%}
-  {%- set temp_relation = make_temp_relation(target_relation)-%}
   {%- set intermediate_relation = make_intermediate_relation(target_relation)-%}
   {%- set backup_relation_type = 'table' if existing_relation is none else existing_relation.type -%}
   {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}
@@ -14,6 +13,12 @@
   {%- set unique_key = config.get('unique_key') -%}
   {%- set full_refresh_mode = (should_full_refresh()  or existing_relation.is_view) -%}
   {%- set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') -%}
+
+  {#-- The temp relation stages the rows the UPSERT reads. As a view the model query
+       stays lazy and the data is written once, straight into the target; as a table
+       the result set is materialized first and then copied over. --#}
+  {%- set tmp_relation_type = ydb_incremental_tmp_relation_type() -%}
+  {%- set temp_relation = make_temp_relation(target_relation).incorporate(type=tmp_relation_type) -%}
 
   -- the temp_ and backup_ relations should not already exist in the database; get_relation
   -- will return None in that case. Otherwise, we get a relation that we can drop
@@ -44,15 +49,16 @@
       {% set relation_for_indexes = intermediate_relation %}
       {% set need_swap = true %}
   {% else %}
-    {% do run_query(get_create_table_as_sql(False, temp_relation, sql)) %}
+    {#-- A temp relation left over by a crashed run would break creation, and after a
+         `tmp_relation_type` switch it may even be of the other kind -- drop whatever
+         is actually there (the cache knows its real type). --#}
+    {% do drop_relation_if_exists(load_cached_relation(temp_relation) or temp_relation) %}
+    {% do run_query(ydb_create_incremental_tmp_relation_sql(temp_relation, sql, tmp_relation_type)) %}
     {% do to_drop.append(temp_relation) %}
     {% set relation_for_indexes = temp_relation %}
-    {% set contract_config = config.get('contract') %}
-    {% if not contract_config or not contract_config.enforced %}
-      {% do adapter.expand_target_column_types(
-               from_relation=temp_relation,
-               to_relation=target_relation) %}
-    {% endif %}
+    {#-- `expand_target_column_types` is deliberately not called here: `alter_column_type`
+         is a no-op in YDB, so it can only ever cost a round trip -- and with a view temp
+         relation reading its columns means running the model query one extra time. --#}
     {#-- Process schema changes. Returns dict of changes if successful. Use source columns for upserting/merging --#}
     {% set dest_columns = process_schema_changes(on_schema_change, temp_relation, existing_relation) %}
     {% if not dest_columns %}
@@ -107,13 +113,65 @@
 
 {%- endmaterialization %}
 
+
+{#--
+    Which kind of relation stages the rows for the UPSERT.
+
+    `view`  (default) -- the model query is wrapped in a view, so the UPSERT reads
+                         through it and the result set is written exactly once.
+    `table`           -- the pre-0.0.16 behaviour: materialize the result set into a
+                         temp table first, then copy it into the target. Slower, but
+                         it snapshots the source before the target is touched.
+--#}
+{% macro ydb_incremental_tmp_relation_type() %}
+  {%- set tmp_relation_type = config.get('tmp_relation_type', 'view') -%}
+
+  {%- if tmp_relation_type not in ['view', 'table'] -%}
+    {{ exceptions.raise_compiler_error(
+        "Invalid value for `tmp_relation_type`: '" ~ tmp_relation_type ~ "'. Expected 'view' or 'table'") }}
+  {%- endif -%}
+
+  {%- set contract_config = config.get('contract') -%}
+  {%- if tmp_relation_type == 'view' and contract_config and contract_config.enforced -%}
+    {#-- a view carries no column definitions, so the contract can only be asserted
+         against a real table --#}
+    {{ return('table') }}
+  {%- endif -%}
+
+  {{ return(tmp_relation_type) }}
+{% endmacro %}
+
+
+{% macro ydb_create_incremental_tmp_relation_sql(relation, sql, tmp_relation_type) %}
+  {%- if tmp_relation_type == 'view' -%}
+    {{ return(ydb_create_tmp_view_as_sql(relation, sql)) }}
+  {%- else -%}
+    {{ return(ydb__create_table_as(False, relation, sql, 'tmp_sql_header')) }}
+  {%- endif -%}
+{% endmacro %}
+
+
+{% macro ydb_create_tmp_view_as_sql(relation, sql) -%}
+  {%- set sql_header = ydb_get_sql_header('tmp_sql_header') -%}
+
+  {{ sql_header if sql_header is not none }}
+
+create view {{ relation.include(database=False) }}
+with (security_invoker = TRUE)
+as {{ sql }}
+
+{%- endmacro %}
+
+
 {% macro ydb__get_merge_sql(target, source, unique_key, dest_columns, incremental_predicates=none) %}
     {% set predicates = [] if incremental_predicates is none else [] + incremental_predicates %}
     {% set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute="name")) %}
     {% set merge_update_columns = config.get('merge_update_columns') %}
     {% set merge_exclude_columns = config.get('merge_exclude_columns') %}
     {% set update_columns = get_merge_update_columns(merge_update_columns, merge_exclude_columns, dest_columns) %}
-    {% set sql_header = config.get('sql_header', none) %}
+    {#-- this statement has a plan of its own, so it takes `merge_sql_header` when the
+         model sets one and falls back to `sql_header` otherwise --#}
+    {% set sql_header = ydb_get_sql_header('merge_sql_header') %}
 
     {% if unique_key %}
         {% if unique_key is sequence and unique_key is not mapping and unique_key is not string %}

--- a/dbt/include/ydb/macros/materializations/models/table.sql
+++ b/dbt/include/ydb/macros/materializations/models/table.sql
@@ -1,5 +1,5 @@
-{% macro ydb__create_table_as(temporary, relation, sql) -%}
-  {%- set sql_header = config.get('sql_header', none) -%}
+{% macro ydb__create_table_as(temporary, relation, sql, sql_header_key=none) -%}
+  {%- set sql_header = ydb_get_sql_header(sql_header_key) -%}
 
   {%- set primary_key_expr = model['config'].get('primary_key') -%}
   {%- if not primary_key_expr -%}

--- a/dbt/include/ydb/macros/materializations/models/view.sql
+++ b/dbt/include/ydb/macros/materializations/models/view.sql
@@ -82,7 +82,7 @@
 {%- endmaterialization -%}
 
 {% macro ydb__create_view_as(relation, sql) -%}
-  {%- set sql_header = config.get('sql_header', none) -%}
+  {%- set sql_header = ydb_get_sql_header() -%}
 
   {{ sql_header if sql_header is not none }}
 

--- a/dbt/include/ydb/macros/materializations/snapshots/helpers.sql
+++ b/dbt/include/ydb/macros/materializations/snapshots/helpers.sql
@@ -37,7 +37,7 @@
 {% endmacro %}
 
 {% macro ydb__create_snapshot_table_as(temporary, relation, sql) -%}
-  {%- set sql_header = config.get('sql_header', none) -%}
+  {%- set sql_header = ydb_get_sql_header('tmp_sql_header') -%}
 
   {%- set columns = config.get('snapshot_table_column_names') or get_snapshot_table_column_names() -%}
 

--- a/dbt/include/ydb/macros/materializations/snapshots/snapshot_merge.sql
+++ b/dbt/include/ydb/macros/materializations/snapshots/snapshot_merge.sql
@@ -1,6 +1,10 @@
 {% macro ydb__snapshot_merge_sql(target, source, insert_cols) -%}
     {%- set insert_cols_csv = insert_cols | join(', ') -%}
     {%- set columns = config.get("snapshot_table_column_names") or get_snapshot_table_column_names() -%}
+    {#-- opt-in only: this step never carried `sql_header`, so there is no fallback --#}
+    {%- set sql_header = ydb_get_sql_header('merge_sql_header', fallback=none) -%}
+
+{{ sql_header if sql_header is not none }}
 
 -- update for matched (closing old versions)
 UPDATE {{ target.render() }} ON

--- a/dbt/include/ydb/macros/sql_header.sql
+++ b/dbt/include/ydb/macros/sql_header.sql
@@ -1,0 +1,29 @@
+{#
+    Per-statement SQL headers.
+
+    `sql_header` is emitted in front of every statement a materialization runs.
+    That is fine for session-level pragmas, but some YQL pragmas are bound to the
+    physical plan of one particular statement -- `ydb.OverridePlanner` addresses
+    stages by positional tx/stage ids -- so a single header can never be valid for
+    all the statements of, say, the incremental materialization.
+
+    Every statement that is not the "main" one therefore gets its own optional
+    config key. When the key is set it *replaces* `sql_header` for that statement
+    only; when it is not set the statement falls back to `sql_header`, which is the
+    behaviour every model had before:
+
+        sql_header        -- default for every statement
+        merge_sql_header  -- the UPSERT of the incremental strategy
+        tmp_sql_header    -- creation of the incremental temp relation
+
+    Setting a per-statement key to an empty string emits no header at all for that
+    statement, which is how a model opts out of the model-wide `sql_header`.
+#}
+
+{% macro ydb_get_sql_header(config_key=none, fallback='sql_header') -%}
+  {%- set header = config.get(config_key, none) if config_key is not none else none -%}
+  {%- if header is none and fallback is not none -%}
+    {%- set header = config.get(fallback, none) -%}
+  {%- endif -%}
+  {{- return(header) -}}
+{%- endmacro %}

--- a/tests/functional/adapter/basic/test_incremental_sql_header.py
+++ b/tests/functional/adapter/basic/test_incremental_sql_header.py
@@ -1,0 +1,60 @@
+import pytest
+
+from dbt.tests.util import run_dbt, write_file
+
+# `tx: 99` can never be a valid transaction id, so whichever statement this header
+# is attached to fails to compile with "Invalid tx id: 99". That makes it a precise
+# probe for *which* statement a header actually ends up on.
+BAD_PRAGMA = 'PRAGMA ydb.OverridePlanner = @@ [ { "tx": 99, "stage": 0, "tasks": 1 } ] @@;'
+
+MODEL_TEMPLATE = """
+{{{{ config(
+    materialized='incremental',
+    primary_key='id',
+    unique_key='id'{extra}
+) }}}}
+select 1l as id, 'a'u as v
+"""
+
+
+def model_sql(**configs):
+    extra = "".join(f",\n    {key}='{value}'" for key, value in configs.items())
+    return MODEL_TEMPLATE.format(extra=extra)
+
+
+class TestIncrementalMergeSqlHeader:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"inc_header.sql": model_sql(merge_sql_header=BAD_PRAGMA)}
+
+    def test_merge_sql_header_only_reaches_the_upsert(self, project):
+        # the first run is a plain CREATE TABLE AS, there is no merge statement yet
+        run_dbt(["run"])
+
+        # the second run goes through the UPSERT, which is where `merge_sql_header` lands
+        results = run_dbt(["run"], expect_pass=False)
+        assert "Invalid tx id: 99" in results[0].message
+
+
+class TestIncrementalSqlHeaderOverrides:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"inc_header.sql": model_sql()}
+
+    def _write_model(self, project, **configs):
+        write_file(model_sql(**configs), project.project_root, "models", "inc_header.sql")
+
+    def test_sql_header_is_inherited_and_can_be_switched_off(self, project):
+        run_dbt(["run"])
+
+        # with no per-statement key set, `sql_header` still goes in front of every
+        # statement -- the behaviour models had before per-statement headers existed
+        self._write_model(project, sql_header=BAD_PRAGMA)
+        results = run_dbt(["run"], expect_pass=False)
+        assert "Invalid tx id: 99" in results[0].message
+
+        # an empty per-statement key means "emit no header for this statement"
+        self._write_model(
+            project, sql_header=BAD_PRAGMA, merge_sql_header="", tmp_sql_header=""
+        )
+        run_dbt(["run"])

--- a/tests/functional/adapter/basic/test_incremental_tmp_relation.py
+++ b/tests/functional/adapter/basic/test_incremental_tmp_relation.py
@@ -1,0 +1,109 @@
+import pytest
+
+from dbt.tests.adapter.basic import files
+from dbt.tests.adapter.basic.test_incremental import BaseIncremental
+from dbt.tests.util import relation_from_name, run_dbt
+
+model_incremental = """
+select * from {{ source('raw', 'seed') }}
+{% if is_incremental() %}
+where id > 10
+{% endif %}
+""".strip()
+
+config_tmp_table = """
+  {{ config(materialized="incremental", primary_key="id", tmp_relation_type="table") }}
+"""
+
+config_bad_tmp_relation_type = """
+  {{ config(materialized="incremental", primary_key="id", tmp_relation_type="ephemeral") }}
+"""
+
+
+class TestIncrementalTmpTableRelation(BaseIncremental):
+    """The pre-0.0.16 path -- stage the rows in a real table -- must keep working."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "incremental.sql": config_tmp_table + model_incremental,
+            "schema.yml": files.schema_base_yml,
+        }
+
+
+class TestIncrementalTmpRelationCleanup:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "inc_tmp.sql": """
+{{ config(materialized='incremental', primary_key='id', unique_key='id') }}
+select 1l as id, 'a'u as v
+"""
+        }
+
+    def test_temp_relation_is_dropped(self, project):
+        run_dbt(["run"])
+        run_dbt(["run"])
+
+        tmp_relation = relation_from_name(project.adapter, "inc_tmp__dbt_tmp")
+        with pytest.raises(Exception):
+            project.run_sql(f"select count(*) from {tmp_relation}", fetch="one")
+
+    def test_stale_temp_relation_does_not_break_the_run(self, project):
+        # a crashed run -- or an adapter version that staged into a table -- can leave
+        # an object of either kind behind under the temp name
+        tmp_relation = relation_from_name(project.adapter, "inc_tmp__dbt_tmp")
+        # DDL has to go through the adapter -- the test helper runs statements inside a
+        # transaction, which YDB does not allow for scheme operations
+        with project.adapter.connection_named("_stale_tmp"):
+            project.adapter.execute(
+                f"create table {tmp_relation} (id Int64 NOT NULL, v Utf8, primary key (id))"
+            )
+
+        run_dbt(["run"])
+
+
+class TestIncrementalInNestedSchema:
+    """A schema is a directory in YDB, so the temp relation is created, read and
+    dropped by a path several levels deep."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "inc_nested.sql": """
+{{ config(materialized='incremental', primary_key='id', unique_key='id', schema='sub') }}
+select 1l as id, 'a'u as v
+"""
+        }
+
+    @pytest.fixture(scope="class", autouse=True)
+    def drop_child_schema(self, project):
+        yield
+        # the harness only drops the top-level test schema, and YDB refuses to remove a
+        # directory that still has children
+        child = project.adapter.Relation.create(
+            database=project.database, schema=f"{project.test_schema}/sub"
+        )
+        with project.adapter.connection_named("_drop_child_schema"):
+            project.adapter.drop_schema(child)
+
+    def test_incremental_runs_in_a_nested_schema(self, project):
+        run_dbt(["run"])
+        run_dbt(["run"])
+
+        model = f"`{project.test_schema}/sub/inc_nested`"
+        assert project.run_sql(f"select count(*) from {model}", fetch="one")[0] == 1
+
+        tmp_relation = f"`{project.test_schema}/sub/inc_nested__dbt_tmp`"
+        with pytest.raises(Exception):
+            project.run_sql(f"select count(*) from {tmp_relation}", fetch="one")
+
+
+class TestInvalidTmpRelationType:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"inc_bad.sql": config_bad_tmp_relation_type + "select 1l as id"}
+
+    def test_invalid_tmp_relation_type_is_rejected(self, project):
+        results = run_dbt(["run"], expect_pass=False)
+        assert "tmp_relation_type" in results[0].message


### PR DESCRIPTION
Two problems in the incremental materialization.

**Double write (#37).** The model's result set was materialized into a temp table and then read back to UPSERT into the target. Staging is now a view by default, so the model query is planned into the UPSERT and the data is written once. `tmp_relation_type='table'` keeps the old path for cases where the source should be snapshotted before the target is touched, or where the cluster has no views.

**One header for every statement (#36).** Building a model takes several statements, and `sql_header` was emitted in front of all of them, so a header could only ever suit one. `merge_sql_header` and `tmp_sql_header` replace `sql_header` for their own statement; an empty value means no header there. Unset keys fall back to `sql_header`, so existing models are unaffected.

Also drops the `expand_target_column_types` call (`alter_column_type` is a no-op in YDB) and drops a leftover temp relation before creating a new one.

Fixes #36
Fixes #37
